### PR TITLE
Fix normalize_intrinsics for intrinsics.ndim > 2

### DIFF
--- a/utils3d/numpy/transforms.py
+++ b/utils3d/numpy/transforms.py
@@ -398,13 +398,13 @@ def normalize_intrinsics(
             1 / width, zeros, 0.5 / width,
             zeros, 1 / height, 0.5 / height,
             zeros, zeros, ones
-        ]).reshape(*zeros.shape, 3, 3)
+        ], axis=-1).reshape(*zeros.shape, 3, 3)
     elif pixel_convention == 'integer-corner':
         transform = np.stack([
             1 / width, zeros, zeros,
             zeros, 1 / height, zeros,
             zeros, zeros, ones
-        ]).reshape(*zeros.shape, 3, 3)
+        ], axis=-1).reshape(*zeros.shape, 3, 3)
     return transform @ intrinsics
 
 
@@ -439,13 +439,13 @@ def denormalize_intrinsics(
             width, zeros, -0.5 * ones,
             zeros, height, -0.5 * ones,
             zeros, zeros, ones
-        ], dim=-1).reshape(*zeros.shape, 3, 3)
+        ], axis=-1).reshape(*zeros.shape, 3, 3)
     elif pixel_convention == 'integer-corner':
         transform = np.stack([
             width, zeros, zeros,
             zeros, height, zeros,
             zeros, zeros, ones
-        ], dim=-1).reshape(*zeros.shape, 3, 3)
+        ], axis=-1).reshape(*zeros.shape, 3, 3)
     return transform @ intrinsics
 
 

--- a/utils3d/torch/transforms.py
+++ b/utils3d/torch/transforms.py
@@ -385,13 +385,13 @@ def normalize_intrinsics(
             1 / width, zeros, 0.5 / width,
             zeros, 1 / height, 0.5 / height,
             zeros, zeros, ones
-        ]).reshape(*zeros.shape, 3, 3)
+        ], dim=-1).reshape(*zeros.shape, 3, 3)
     elif pixel_convention == 'integer-corner':
         transform = torch.stack([
             1 / width, zeros, zeros,
             zeros, 1 / height, zeros,
             zeros, zeros, ones
-        ]).reshape(*zeros.shape, 3, 3)
+        ], dim=-1).reshape(*zeros.shape, 3, 3)
     return transform @ intrinsics
 
 


### PR DESCRIPTION
Fixes a bug in `denormalize_intrinsics` when handling intrinsics with ndim > 2. Same logic as #14 
Also, fixes bug introduced in #14 (used `dim` in `np.stack` instead of `axis`)